### PR TITLE
Fix: 방 생성 API, Socket 닉네임 저장 API 

### DIFF
--- a/src/Controllers/apiController.js
+++ b/src/Controllers/apiController.js
@@ -10,17 +10,17 @@ function generateRandomCode(n) {
 
 export const genNewRoom = async (req, res) => {
     //4자리 랜덤 난수의 초대 코드 생성
-    let inviteCode = generateRandomCode(4);
+    const inviteCode = generateRandomCode(4);
 
     //초대 코드 중복 여부 검사
     const roomExist = await Room.exists({ inviteCode: inviteCode });
-
+    console.log(roomExist);
     if(roomExist){
         return genNewRoom();
     }
 
     try{
-        Room.create({
+        await Room.create({
             inviteCode: inviteCode
         })
     } catch(error) {
@@ -31,7 +31,7 @@ export const genNewRoom = async (req, res) => {
 
     return res.status(200).json({
         inviteCode: inviteCode
-    })
+    });
 };
 
 export const callRoom = async (req, res) => {


### PR DESCRIPTION
1. 방 생성 API
개요 : 방 생성 API를 호출하여도 방이 생성되지 않는 오류가 발생함.
원인: 방 생성 로직이 비동기적으로 처리되도록 설정되어 있었음.
해결: 방 생성 로직이 동기적으로 처리되도록 변경함.

2.  유저 닉네임을 저장하는 로직
개요: localStorage 에 저장되어있는 닉네임을 서버에서 참조하여 저장하려고하였으나, localStorage는 서버가 참조 불가함.
원인: localStorage는 클라이언트 side에서만 활용할 목적으로 만들어진 기능임.
해결: "enterRoom" socket 이벤트 감지될 때, Front로 부터 username 매개변수를 추가로 전달받아, socket.nickname 에 저장하도록 로직 변경함.